### PR TITLE
Remove parâmetro de versão do REPL online

### DIFF
--- a/ramda.md
+++ b/ramda.md
@@ -10,7 +10,7 @@
 
 * **Homepage:** http://ramdajs.com/
 * **Docs:** http://ramdajs.com/docs/#
-* **REPL online:** http://ramdajs.com/repl/?v=0.23.0
+* **REPL online:** http://ramdajs.com/repl/
 
 ## Intro
 


### PR DESCRIPTION
Garante que o link apontará sempre para o REPL online com a última versão do Ramda. 